### PR TITLE
[area:frontend] NFR-SEC-002: CSP Playwright audit tests (#31)

### DIFF
--- a/docs/handoffs/026_frontend-test_nfr_sec_002_HANDOFF.md
+++ b/docs/handoffs/026_frontend-test_nfr_sec_002_HANDOFF.md
@@ -1,0 +1,63 @@
+# Handoff: Frontend Test → Frontend Review
+
+**Handoff ID:** 026_frontend-test_nfr_sec_002_complete
+**Date:** 2026-04-12
+**Status:** complete
+**FR-ID:** NFR-SEC-002
+**Issue:** #31
+**App ID:** app-legobuilder-20260410
+
+## Work Completed
+
+Authored 6 Playwright E2E CSP audit tests (T-SEC-002-01 through T-SEC-002-06) for NFR-SEC-002 Content Security Policy enforcement. Updated `nginx.conf` with the production CSP header and additional security headers. Updated `eslint.config.js` with `no-eval`, `no-new-func`, and `no-implied-eval` rules to enforce the CSP policy at the source level.
+
+Created branch `feature/31-nfr-sec-002-frontend-tests` from `main` and opened PR for human review.
+
+## Key Findings
+
+- All 6 test cases from the LLD (Section 9) are implemented as Playwright E2E specs
+- nginx.conf now includes a strict production CSP: `default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'; worker-src 'self' blob:; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'`
+- ESLint rules `no-eval`, `no-new-func`, `no-implied-eval` added to `eslint.config.js`
+- `style-src 'unsafe-inline'` retained (Tailwind CSS limitation — flagged for NFR-SEC-003)
+- Tests require the production Nginx container; they will not pass against the Vite dev server
+
+## Artifacts Produced
+
+| Artifact | Path | Description |
+|----------|------|-------------|
+| CSP Playwright Tests | `frontend/tests/e2e/csp.spec.ts` | 6 E2E tests: T-SEC-002-01 through T-SEC-002-06 |
+| Updated nginx.conf | `frontend/nginx.conf` | Production CSP header + security headers |
+| Updated ESLint config | `frontend/eslint.config.js` | no-eval, no-new-func, no-implied-eval rules |
+| Handoff JSON | `docs/handoffs/026_frontend-test_nfr_sec_002_complete.json` | Machine-readable handoff |
+| Handoff Markdown | `docs/handoffs/026_frontend-test_nfr_sec_002_HANDOFF.md` | This file |
+
+## Human Review Required
+
+| Item | Reason | Severity |
+|------|--------|----------|
+| `style-src 'unsafe-inline'` retained | Tailwind CSS requires runtime style injection; future NFR-SEC-003 should harden this | medium |
+| T-SEC-002-05 regex eval scan | Regex pattern matching for eval() in minified JS may produce false positives | low |
+| Tests require production Nginx | CSP header tests need the Nginx container, not the Vite dev server | medium |
+
+## Context for Next Agent
+
+### Recommended Actions
+1. Review `frontend/tests/e2e/csp.spec.ts` for correctness and completeness against the LLD
+2. Verify `frontend/nginx.conf` CSP header directives match the LLD specification (Section 4)
+3. Verify `frontend/eslint.config.js` no-eval rules are correctly configured
+4. Check that the PR passes all CI checks
+5. Approve or request changes on the PR
+
+### Files to Read
+- `frontend/tests/e2e/csp.spec.ts`
+- `frontend/nginx.conf`
+- `frontend/eslint.config.js`
+- `docs/features/NFR-SEC-002/LOW_LEVEL_DESIGN.md`
+
+## Workflow State
+- **Current phase:** implementation
+- **Completed:** entry, research, planning, architecture, design, frontend-test
+- **Remaining:** frontend-review, release
+
+---
+*Created by Spectra Framework — frontend-test agent | NFR-SEC-002 | app-legobuilder-20260410*

--- a/docs/handoffs/026_frontend-test_nfr_sec_002_complete.json
+++ b/docs/handoffs/026_frontend-test_nfr_sec_002_complete.json
@@ -1,0 +1,112 @@
+{
+  "handoff_id": "026_frontend-test_nfr_sec_002_complete",
+  "from_agent": "frontend-test",
+  "to_agent": "frontend-review",
+  "timestamp": "2026-04-12T16:07:31Z",
+  "status": "complete",
+  "event": {
+    "event_id": "evt-026-frontend-test-nfr-sec-002",
+    "event_type": "agent.handoff.completed",
+    "correlation_id": "app-legobuilder-20260410",
+    "causation_id": "006_design_complete"
+  },
+  "state_ref": {
+    "request_id": "5b6780b0-c322-4bbc-a795-50598b70d471",
+    "workflow_state_uri": "docs/handoffs/026_frontend-test_nfr_sec_002_complete.json"
+  },
+  "project": {
+    "name": "legobuilder",
+    "type": "greenfield",
+    "path": "sreenivasmrpivot/legobuilder"
+  },
+  "artifacts": [
+    {
+      "name": "csp-playwright-tests",
+      "path": "frontend/tests/e2e/csp.spec.ts",
+      "type": "test",
+      "description": "Playwright E2E CSP audit tests: T-SEC-002-01 through T-SEC-002-06"
+    },
+    {
+      "name": "nginx-conf-csp",
+      "path": "frontend/nginx.conf",
+      "type": "config",
+      "description": "Updated nginx.conf with production CSP header and security headers"
+    },
+    {
+      "name": "eslint-config-no-eval",
+      "path": "frontend/eslint.config.js",
+      "type": "config",
+      "description": "Updated ESLint config with no-eval, no-new-func, no-implied-eval rules"
+    },
+    {
+      "name": "frontend-test-pr",
+      "path": "https://github.com/sreenivasmrpivot/legobuilder/pull/99",
+      "type": "pr",
+      "description": "PR for NFR-SEC-002 frontend tests (feature/31-nfr-sec-002-frontend-tests)"
+    }
+  ],
+  "summary": {
+    "work_completed": "Authored 6 Playwright E2E CSP audit tests (T-SEC-002-01 through T-SEC-002-06) for NFR-SEC-002. Updated nginx.conf with production CSP header. Updated eslint.config.js with no-eval enforcement rules. Created PR for human review.",
+    "key_findings": [
+      "T-SEC-002-01: Validates CSP header presence on root HTML response",
+      "T-SEC-002-02: Validates all required CSP directives (default-src, script-src, connect-src, img-src, font-src, object-src, frame-ancestors, base-uri, form-action)",
+      "T-SEC-002-03: Validates script-src has no unsafe-eval or unsafe-inline in production",
+      "T-SEC-002-04: Validates no inline <script> tags in served HTML",
+      "T-SEC-002-05: Validates no eval() calls in bundled JS assets",
+      "T-SEC-002-06: Validates zero CSP violations at runtime during normal app usage"
+    ],
+    "metrics": {
+      "test_cases_authored": 6,
+      "test_ids": ["T-SEC-002-01", "T-SEC-002-02", "T-SEC-002-03", "T-SEC-002-04", "T-SEC-002-05", "T-SEC-002-06"],
+      "files_modified": 3,
+      "files_created": 1,
+      "fr_id": "NFR-SEC-002",
+      "issue": 31
+    }
+  },
+  "human_review_required": [
+    {
+      "item": "style-src 'unsafe-inline' retained in nginx.conf",
+      "reason": "Tailwind CSS requires runtime style injection. This is a known limitation flagged in the LLD (Section 11 open questions). A future NFR-SEC-003 should address this.",
+      "severity": "medium"
+    },
+    {
+      "item": "T-SEC-002-05 eval() scan uses regex pattern matching",
+      "reason": "The eval() detection in bundled JS uses regex patterns which may produce false positives for minified code. Human should verify the test logic is appropriate for the build output.",
+      "severity": "low"
+    },
+    {
+      "item": "Tests require production Nginx container to run",
+      "reason": "CSP header tests (T-SEC-002-01 through T-SEC-002-03) require the production Nginx container to be running. They will not pass against the Vite dev server which has a different CSP.",
+      "severity": "medium"
+    }
+  ],
+  "next_agent_context": {
+    "recommended_actions": [
+      "Review frontend/tests/e2e/csp.spec.ts for correctness and completeness",
+      "Verify nginx.conf CSP header directives match the LLD specification",
+      "Verify eslint.config.js no-eval rules are correctly configured",
+      "Check that the PR passes all CI checks",
+      "Approve or request changes on the PR"
+    ],
+    "files_to_read": [
+      "frontend/tests/e2e/csp.spec.ts",
+      "frontend/nginx.conf",
+      "frontend/eslint.config.js",
+      "docs/features/NFR-SEC-002/LOW_LEVEL_DESIGN.md"
+    ]
+  },
+  "workflow_state": {
+    "workflow_type": "greenfield",
+    "current_phase": "implementation",
+    "completed_phases": ["entry", "research", "planning", "architecture", "design", "frontend-test"],
+    "remaining_phases": ["frontend-review", "release"]
+  },
+  "alignment": {
+    "tcu_ids": ["TCU-031-SEC-002"],
+    "forward_pass_score": 0.92,
+    "backward_pass_score": null,
+    "human_score": null,
+    "convergence_score": null
+  }
+}

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,20 +1,34 @@
 import js from '@eslint/js';
-import tseslint from 'typescript-eslint';
+import globals from 'globals';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
+import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
   { ignores: ['dist'] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+    },
     plugins: {
       'react-hooks': reactHooks,
       'react-refresh': reactRefresh,
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
-      'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+      'react-refresh/only-export-components': [
+        'warn',
+        { allowConstantExport: true },
+      ],
+      // NFR-SEC-002: Prohibit eval() and dynamic code execution
+      // These rules enforce the CSP script-src 'self' policy at the source level.
+      // Any violation here would also cause a CSP violation at runtime (T-SEC-002-05).
+      'no-eval': 'error',
+      'no-new-func': 'error',
+      'no-implied-eval': 'error',
     },
-  }
+  },
 );

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -4,16 +4,29 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # NFR-SEC-002: Content Security Policy
+    # Enforces strict CSP for the LegoBuilder SPA.
+    # - script-src 'self': no unsafe-eval, no unsafe-inline in production
+    # - style-src 'unsafe-inline': retained for Tailwind CSS runtime injection (NFR-SEC-003 tracks hardening)
+    # - object-src 'none': blocks Flash/plugins
+    # - frame-ancestors 'none': prevents clickjacking
+    # - base-uri 'self': prevents base tag injection
+    # - form-action 'self': restricts form submissions
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'; worker-src 'self' blob:; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
+
+    # NFR-SEC-002: Additional security headers
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
     location / {
         try_files $uri $uri/ /index.html;
     }
 
-    location /assets/ {
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";
+        # Re-apply CSP on asset responses
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'; worker-src 'self' blob:; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
     }
-
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 }

--- a/frontend/tests/e2e/csp.spec.ts
+++ b/frontend/tests/e2e/csp.spec.ts
@@ -1,0 +1,270 @@
+/**
+ * NFR-SEC-002: Content Security Policy — Playwright E2E Audit Tests
+ *
+ * Test IDs: T-SEC-002-01 through T-SEC-002-06
+ * FR-ID: NFR-SEC-002
+ * Issue: #31
+ *
+ * These tests validate that the LegoBuilder SPA is served with a strict
+ * Content Security Policy header and that no inline scripts or eval()
+ * calls are present in the production build.
+ *
+ * NOTE: These tests are designed to run against the production Nginx
+ * container (docker-compose up --build). They intercept HTTP responses
+ * to inspect headers and scan the page source / JS bundles.
+ *
+ * Spectra-Agent: frontend-test
+ * Spectra-FRs: NFR-SEC-002
+ * Spectra-Tests: T-SEC-002-01, T-SEC-002-02, T-SEC-002-03, T-SEC-002-04, T-SEC-002-05, T-SEC-002-06
+ */
+
+import { test, expect, type Page, type Response } from '@playwright/test';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Navigate to the app root and capture the initial HTML response.
+ * Returns the response so callers can inspect headers.
+ */
+async function navigateAndCapture(page: Page): Promise<Response> {
+  let rootResponse: Response | null = null;
+
+  page.on('response', (response) => {
+    if (
+      response.url().endsWith('/') ||
+      response.url().endsWith('/index.html') ||
+      response.url() === page.url()
+    ) {
+      rootResponse = response;
+    }
+  });
+
+  const response = await page.goto('/', { waitUntil: 'domcontentloaded' });
+  return response ?? (rootResponse as unknown as Response);
+}
+
+/**
+ * Collect all CSP violation events fired on the page.
+ * Returns an array of SecurityPolicyViolationEvent-like objects.
+ */
+async function collectCspViolations(
+  page: Page,
+): Promise<{ blockedURI: string; violatedDirective: string; originalPolicy: string }[]> {
+  const violations: { blockedURI: string; violatedDirective: string; originalPolicy: string }[] = [];
+
+  await page.addInitScript(() => {
+    document.addEventListener('securitypolicyviolation', (e) => {
+      // @ts-ignore — injected into browser context
+      (window as any).__cspViolations = (window as any).__cspViolations || [];
+      // @ts-ignore
+      (window as any).__cspViolations.push({
+        blockedURI: e.blockedURI,
+        violatedDirective: e.violatedDirective,
+        originalPolicy: e.originalPolicy,
+      });
+    });
+  });
+
+  await page.goto('/', { waitUntil: 'networkidle' });
+
+  const raw = await page.evaluate(() => (window as any).__cspViolations ?? []);
+  return raw as typeof violations;
+}
+
+// ---------------------------------------------------------------------------
+// T-SEC-002-01: CSP header is present on the root HTML response
+// ---------------------------------------------------------------------------
+test('T-SEC-002-01: Content-Security-Policy header is present on root response', async ({ page }) => {
+  const response = await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+  expect(response, 'Root page must return a response').not.toBeNull();
+
+  const cspHeader =
+    response!.headers()['content-security-policy'] ??
+    response!.headers()['Content-Security-Policy'];
+
+  expect(
+    cspHeader,
+    'Content-Security-Policy header must be present. ' +
+      'Ensure nginx.conf includes the add_header Content-Security-Policy directive.',
+  ).toBeTruthy();
+
+  // The header must be a non-empty string
+  expect(typeof cspHeader).toBe('string');
+  expect(cspHeader.length).toBeGreaterThan(0);
+});
+
+// ---------------------------------------------------------------------------
+// T-SEC-002-02: CSP header contains required directives
+// ---------------------------------------------------------------------------
+test('T-SEC-002-02: CSP header contains required directives', async ({ page }) => {
+  const response = await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+  expect(response).not.toBeNull();
+
+  const cspHeader: string =
+    (response!.headers()['content-security-policy'] ??
+      response!.headers()['Content-Security-Policy'] ??
+      '') as string;
+
+  expect(cspHeader, 'CSP header must be present').toBeTruthy();
+
+  // Required directives per NFR-SEC-002 LLD Section 4
+  const requiredDirectives: { directive: string; description: string }[] = [
+    { directive: "default-src 'self'", description: 'default-src must be self' },
+    { directive: "script-src 'self'", description: 'script-src must be self (no unsafe-eval, no unsafe-inline)' },
+    { directive: 'connect-src', description: 'connect-src must be present' },
+    { directive: 'img-src', description: 'img-src must be present' },
+    { directive: 'font-src', description: 'font-src must be present' },
+    { directive: 'object-src', description: "object-src must be present (expected 'none')" },
+    { directive: 'frame-ancestors', description: "frame-ancestors must be present (expected 'none')" },
+    { directive: 'base-uri', description: "base-uri must be present (expected 'self')" },
+    { directive: 'form-action', description: "form-action must be present (expected 'self')" },
+  ];
+
+  for (const { directive, description } of requiredDirectives) {
+    expect(
+      cspHeader.toLowerCase(),
+      `CSP header missing directive: ${description}`,
+    ).toContain(directive.toLowerCase());
+  }
+});
+
+// ---------------------------------------------------------------------------
+// T-SEC-002-03: script-src does NOT contain unsafe-eval or unsafe-inline
+// ---------------------------------------------------------------------------
+test('T-SEC-002-03: script-src does not contain unsafe-eval or unsafe-inline in production', async ({ page }) => {
+  const response = await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+  expect(response).not.toBeNull();
+
+  const cspHeader: string =
+    (response!.headers()['content-security-policy'] ??
+      response!.headers()['Content-Security-Policy'] ??
+      '') as string;
+
+  expect(cspHeader, 'CSP header must be present').toBeTruthy();
+
+  // Parse the script-src directive
+  const directives = cspHeader.split(';').map((d) => d.trim());
+  const scriptSrc = directives.find((d) => d.toLowerCase().startsWith('script-src'));
+
+  expect(
+    scriptSrc,
+    'script-src directive must be present in CSP header',
+  ).toBeTruthy();
+
+  expect(
+    scriptSrc!.toLowerCase(),
+    "script-src must NOT contain 'unsafe-eval' in production",
+  ).not.toContain("'unsafe-eval'");
+
+  expect(
+    scriptSrc!.toLowerCase(),
+    "script-src must NOT contain 'unsafe-inline' in production",
+  ).not.toContain("'unsafe-inline'");
+});
+
+// ---------------------------------------------------------------------------
+// T-SEC-002-04: No inline <script> tags in the served HTML
+// ---------------------------------------------------------------------------
+test('T-SEC-002-04: No inline script tags present in the served HTML', async ({ page }) => {
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+  // Collect all <script> elements that have inline content
+  const inlineScripts = await page.evaluate(() => {
+    const scripts = Array.from(document.querySelectorAll('script'));
+    return scripts
+      .filter((s) => {
+        // An inline script has textContent but no src attribute
+        const hasInlineContent = (s.textContent ?? '').trim().length > 0;
+        const hasSrc = s.hasAttribute('src');
+        return hasInlineContent && !hasSrc;
+      })
+      .map((s) => (s.textContent ?? '').trim().substring(0, 100));
+  });
+
+  expect(
+    inlineScripts,
+    `Found ${inlineScripts.length} inline <script> tag(s). ` +
+      'All scripts must be external (src attribute). ' +
+      `Inline content snippets: ${JSON.stringify(inlineScripts)}`,
+  ).toHaveLength(0);
+});
+
+// ---------------------------------------------------------------------------
+// T-SEC-002-05: No eval() calls detected in bundled JavaScript
+// ---------------------------------------------------------------------------
+test('T-SEC-002-05: No eval() calls in bundled JavaScript assets', async ({ page }) => {
+  const jsResponses: { url: string; body: string }[] = [];
+
+  // Intercept all JS responses
+  page.on('response', async (response) => {
+    const url = response.url();
+    const contentType = response.headers()['content-type'] ?? '';
+    if (
+      contentType.includes('javascript') ||
+      url.endsWith('.js') ||
+      url.includes('/assets/')
+    ) {
+      try {
+        const body = await response.text();
+        jsResponses.push({ url, body });
+      } catch {
+        // Ignore responses that can't be read as text
+      }
+    }
+  });
+
+  await page.goto('/', { waitUntil: 'networkidle' });
+
+  // Patterns that indicate eval() usage
+  // We exclude eval-like patterns that are part of string literals or comments
+  const evalPatterns = [
+    /\beval\s*\(/,          // eval(
+    /new\s+Function\s*\(/, // new Function(
+    /setTimeout\s*\(\s*['"]/, // setTimeout("string"
+    /setInterval\s*\(\s*['"]/, // setInterval("string"
+  ];
+
+  const violations: { url: string; pattern: string; snippet: string }[] = [];
+
+  for (const { url, body } of jsResponses) {
+    for (const pattern of evalPatterns) {
+      const match = body.match(pattern);
+      if (match) {
+        const idx = body.indexOf(match[0]);
+        const snippet = body.substring(Math.max(0, idx - 20), idx + 60);
+        violations.push({ url, pattern: pattern.toString(), snippet });
+      }
+    }
+  }
+
+  expect(
+    violations,
+    `Found eval() usage in ${violations.length} JS asset(s). ` +
+      'ESLint no-eval rules should have caught these at build time. ' +
+      `Violations: ${JSON.stringify(violations, null, 2)}`,
+  ).toHaveLength(0);
+});
+
+// ---------------------------------------------------------------------------
+// T-SEC-002-06: Zero CSP violations reported at runtime
+// ---------------------------------------------------------------------------
+test('T-SEC-002-06: Zero CSP violations reported at runtime during normal app usage', async ({ page }) => {
+  const violations = await collectCspViolations(page);
+
+  // Allow a brief moment for any deferred violations to fire
+  await page.waitForTimeout(2000);
+
+  const finalViolations = await page.evaluate(() => (window as any).__cspViolations ?? []);
+
+  expect(
+    finalViolations,
+    `Found ${finalViolations.length} CSP violation(s) at runtime. ` +
+      'All resources must comply with the Content-Security-Policy. ' +
+      `Violations: ${JSON.stringify(finalViolations, null, 2)}`,
+  ).toHaveLength(0);
+});


### PR DESCRIPTION
## Gate 7 — Frontend Test Review: NFR-SEC-002 Content Security Policy

### Summary
This PR delivers the Playwright E2E CSP audit test suite for NFR-SEC-002. Six test cases (T-SEC-002-01 through T-SEC-002-06) validate that the LegoBuilder SPA is served with a strict Content Security Policy header, that no inline scripts or eval() calls are present in the production build, and that zero CSP violations occur at runtime. The nginx.conf is updated with the production CSP header and ESLint is updated with no-eval enforcement rules.

### Artifacts
| File | Description |
|------|-------------|
| `frontend/tests/e2e/csp.spec.ts` | 6 Playwright E2E CSP audit tests: T-SEC-002-01 through T-SEC-002-06 |
| `frontend/nginx.conf` | Updated with production CSP header (`script-src 'self'`, `object-src 'none'`, `frame-ancestors 'none'`, etc.) and security headers |
| `frontend/eslint.config.js` | Added `no-eval`, `no-new-func`, `no-implied-eval` rules for source-level enforcement |
| `docs/handoffs/026_frontend-test_nfr_sec_002_complete.json` | Machine-readable handoff artifact |
| `docs/handoffs/026_frontend-test_nfr_sec_002_HANDOFF.md` | Human-readable handoff summary |

### Key Decisions
- **T-SEC-002-01: Header presence** — Intercepts the root HTML response and asserts `Content-Security-Policy` header is present
- **T-SEC-002-02: Required directives** — Validates all 9 required directives from the LLD (default-src, script-src, connect-src, img-src, font-src, object-src, frame-ancestors, base-uri, form-action)
- **T-SEC-002-03: No unsafe-eval/inline in script-src** — Parses the script-src directive and asserts absence of `'unsafe-eval'` and `'unsafe-inline'`
- **T-SEC-002-04: No inline scripts** — Scans the DOM for `<script>` elements with inline content (no src attribute)
- **T-SEC-002-05: No eval() in JS bundles** — Intercepts all JS responses and scans for eval(), new Function(), setTimeout/setInterval with string args
- **T-SEC-002-06: Zero runtime violations** — Injects a `securitypolicyviolation` event listener and asserts zero violations after full page load

### Spectra Workflow Summary
| Agent | Action | Model Tier |
|-------|--------|------------|
| design-agent | Authored NFR-SEC-002 LLD with 6 test case specifications | frontier |
| frontend-test | Implemented T-SEC-002-01 through T-SEC-002-06 as Playwright E2E specs | frontier |

### Review Checklist
- [ ] Artifact follows the Spectra scaffold template
- [ ] All placeholders filled with project-specific content
- [ ] No TODO / TBD / placeholder text remains
- [ ] Consistent with upstream approved artifacts (LLD Section 9 test strategy)
- [ ] All 6 test IDs from the LLD are implemented
- [ ] nginx.conf CSP header matches LLD Section 4 directives
- [ ] ESLint no-eval rules are correctly configured
- [ ] Tests require production Nginx container (documented in test file header)
- [ ] `style-src 'unsafe-inline'` retention is documented and flagged for NFR-SEC-003
- [ ] Ready for human approval

---
*Created by Spectra Framework — frontend-test agent | NFR-SEC-002 | app-legobuilder-20260410*