### PR TITLE
[area:frontend] NFR-SCALE-001: Scene Scalability Performance Test Suite (#30)

### DIFF
--- a/docs/handoffs/026_frontend-test_nfr_scale_001_HANDOFF.md
+++ b/docs/handoffs/026_frontend-test_nfr_scale_001_HANDOFF.md
@@ -1,0 +1,103 @@
+# Handoff: Frontend Test → Frontend Review
+
+**Handoff ID:** 026_frontend-test_nfr_scale_001_complete
+**FR-ID:** NFR-SCALE-001
+**Issue:** #30
+**Date:** 2026-04-12
+**Status:** complete
+
+---
+
+## Work Completed
+
+Authored the complete performance test suite for NFR-SCALE-001 (Scene Scalability — 500 Bricks). All files are pushed to branch `feature/30-nfr-scale-001-frontend-tests` and a PR is opened for Gate 6b human review.
+
+### Test Infrastructure Created
+
+| File | Purpose |
+|------|---------|
+| `frontend/tests/performance/scalability.test.ts` | Main Vitest + Puppeteer test suite |
+| `frontend/tests/performance/helpers/ScalabilityThresholds.ts` | Threshold constants (MIN_FPS=60, MAX_HEAP_MB=200) |
+| `frontend/tests/performance/helpers/BrickScenePopulator.ts` | Programmatic brick placement via `window.__sceneStore` |
+| `frontend/tests/performance/helpers/FPSMeter.ts` | rAF-based FPS measurement |
+| `frontend/tests/performance/helpers/HeapMonitor.ts` | CDP heap memory measurement |
+| `frontend/tests/performance/fixtures/brickFixtures.ts` | Deterministic 25×20 grid brick fixtures |
+| `frontend/vitest.performance.config.ts` | Isolated Vitest config for performance tests |
+| `.github/workflows/scalability-test.yml` | GitHub Actions CI job (requires manual push by repo owner) |
+
+---
+
+## Key Decisions
+
+- **Puppeteer + CDP** for accurate in-browser FPS and heap measurement (not jsdom mock)
+- **`window.__sceneStore` injection** via `page.evaluate()` for deterministic, UI-free brick placement
+- **`--use-gl=swiftshader`** Chromium flag for software rendering fallback in CI (GPU may be unavailable)
+- **2000ms FPS window** for statistical stability (>=120 frames at 60 FPS)
+- **500ms stabilization delay** after brick population before measuring
+- **Sequential test execution** (`singleFork: true`) — Puppeteer sessions cannot be safely parallelized
+- **Fixture integrity tests** included (no duplicate positions, prefix consistency)
+
+---
+
+## Artifacts Produced
+
+| Artifact | Path | Description |
+|----------|------|-------------|
+| Main test suite | `frontend/tests/performance/scalability.test.ts` | T-PERF-SCALE-001-01 and T-PERF-SCALE-001-02 |
+| Threshold constants | `frontend/tests/performance/helpers/ScalabilityThresholds.ts` | MIN_FPS, MAX_HEAP_MB, delays |
+| Brick populator | `frontend/tests/performance/helpers/BrickScenePopulator.ts` | Injects bricks via sceneStore |
+| FPS meter | `frontend/tests/performance/helpers/FPSMeter.ts` | rAF-based measurement |
+| Heap monitor | `frontend/tests/performance/helpers/HeapMonitor.ts` | CDP heap measurement |
+| Brick fixtures | `frontend/tests/performance/fixtures/brickFixtures.ts` | Deterministic position data |
+| Vitest config | `frontend/vitest.performance.config.ts` | Isolated performance test config |
+| CI workflow | `.github/workflows/scalability-test.yml` | Provided in PR body (PAT restriction) |
+| Handoff JSON | `docs/handoffs/026_frontend-test_nfr_scale_001_complete.json` | Machine-readable handoff |
+
+---
+
+## Human Review Required
+
+| Item | Reason | Severity |
+|------|--------|----------|
+| `window.__sceneStore` exposure in `main.tsx` | App integration change required; security review needed | **high** |
+| `data-testid="scene-canvas"` on `<Canvas>` | Puppeteer readiness selector; Canvas component must be updated | **medium** |
+| `puppeteer`, `serve`, `wait-on` devDependencies | New packages in `package.json`; version pinning review | **medium** |
+| SwiftShader FPS threshold (LLD Open Question #2) | CI uses software rendering; 60 FPS may not be achievable | **high** |
+| `.github/workflows/scalability-test.yml` | PAT lacks workflow scope; repo owner must push manually | **medium** |
+
+---
+
+## Context for Next Agent
+
+### Recommended Actions
+
+1. Review all test files for correctness against LLD Section 3 component specs
+2. Verify `BrickScenePopulator` uses the correct `sceneStore` API (`addBrick` vs `placeBrick`)
+3. Confirm `FPSMeter` measurement window (2000ms) is sufficient for statistical stability
+4. Confirm `HeapMonitor` CDP method (`Runtime.getHeapUsage`) is available in Puppeteer v22
+5. Review CI workflow YAML in PR body and push to `.github/workflows/scalability-test.yml`
+6. Flag any issues with `--use-gl=swiftshader` and 60 FPS threshold in CI
+7. Approve or request changes on the PR
+
+### Files to Read
+
+- `frontend/tests/performance/scalability.test.ts`
+- `frontend/tests/performance/helpers/BrickScenePopulator.ts`
+- `frontend/tests/performance/helpers/FPSMeter.ts`
+- `frontend/tests/performance/helpers/HeapMonitor.ts`
+- `frontend/tests/performance/helpers/ScalabilityThresholds.ts`
+- `frontend/tests/performance/fixtures/brickFixtures.ts`
+- `frontend/vitest.performance.config.ts`
+- `docs/features/NFR-SCALE-001/LOW_LEVEL_DESIGN.md`
+
+---
+
+## Workflow State
+
+- **Current phase:** frontend_test_complete
+- **Completed:** design, frontend_test
+- **Remaining:** frontend_review, implementation, release
+
+---
+
+*Created by Spectra Framework — frontend-test agent*

--- a/docs/handoffs/026_frontend-test_nfr_scale_001_complete.json
+++ b/docs/handoffs/026_frontend-test_nfr_scale_001_complete.json
@@ -1,0 +1,121 @@
+{
+  "handoff_id": "026_frontend-test_nfr_scale_001_complete",
+  "from_agent": "frontend-test",
+  "to_agent": "frontend-review",
+  "target_repo": "sreenivasmrpivot/legobuilder",
+  "app_id": "app-legobuilder-20260410",
+  "timestamp": "2026-04-12T16:08:51Z",
+  "status": "complete",
+  "summary": "Frontend Test Agent — NFR-SCALE-001: Scene Scalability (500 Bricks)\n\nCreated branch feature/30-nfr-scale-001-frontend-tests from main and authored the complete performance test suite for NFR-SCALE-001. All test infrastructure files are pushed and a PR is opened for Gate 6b human review.",
+  "workflow_state": {
+    "current_phase": "frontend_test_complete",
+    "workflow_type": "pure_greenfield",
+    "completed_phases": ["design", "frontend_test"],
+    "remaining_phases": ["frontend_review", "implementation", "release"]
+  },
+  "artifacts": [
+    {
+      "name": "scalability.test.ts",
+      "path": "frontend/tests/performance/scalability.test.ts",
+      "type": "test",
+      "description": "Main Vitest + Puppeteer performance test suite for NFR-SCALE-001. Tests T-PERF-SCALE-001-01 (100/250 bricks >=60 FPS) and T-PERF-SCALE-001-02 (500 bricks >=60 FPS + heap <200 MB)."
+    },
+    {
+      "name": "ScalabilityThresholds.ts",
+      "path": "frontend/tests/performance/helpers/ScalabilityThresholds.ts",
+      "type": "test-helper",
+      "description": "Threshold constants: MIN_FPS=60, MAX_HEAP_MB=200, STABILIZATION_DELAY_MS=500, MEASUREMENT_WINDOW_MS=2000."
+    },
+    {
+      "name": "BrickScenePopulator.ts",
+      "path": "frontend/tests/performance/helpers/BrickScenePopulator.ts",
+      "type": "test-helper",
+      "description": "Programmatic brick placement via window.__sceneStore.getState().addBrick(). Deterministic 25x20 grid layout."
+    },
+    {
+      "name": "FPSMeter.ts",
+      "path": "frontend/tests/performance/helpers/FPSMeter.ts",
+      "type": "test-helper",
+      "description": "requestAnimationFrame-based FPS measurement. Returns averageFPS, frameCount, elapsedMs, min/max frame intervals."
+    },
+    {
+      "name": "HeapMonitor.ts",
+      "path": "frontend/tests/performance/helpers/HeapMonitor.ts",
+      "type": "test-helper",
+      "description": "CDP Runtime.getHeapUsage heap measurement. Forces GC before measurement. Returns usedMB, totalMB, usagePercent."
+    },
+    {
+      "name": "brickFixtures.ts",
+      "path": "frontend/tests/performance/fixtures/brickFixtures.ts",
+      "type": "test-fixture",
+      "description": "Pre-computed deterministic brick position data for 100/250/500 brick scenes. Includes assertNoDuplicatePositions guard."
+    },
+    {
+      "name": "vitest.performance.config.ts",
+      "path": "frontend/vitest.performance.config.ts",
+      "type": "config",
+      "description": "Isolated Vitest config for performance tests. Node environment, 120s timeout, sequential forks pool, JSON reporter."
+    },
+    {
+      "name": "scalability-test.yml (pending)",
+      "path": ".github/workflows/scalability-test.yml",
+      "type": "ci",
+      "description": "GitHub Actions CI job for NFR-SCALE-001. Requires manual push by repo owner (PAT lacks workflow scope). Content provided in PR body."
+    }
+  ],
+  "human_review_required": [
+    {
+      "item": "window.__sceneStore exposure in main.tsx",
+      "reason": "The test harness requires sceneStore to be exposed on window in non-production mode. This is an app integration change that must be reviewed for security implications.",
+      "severity": "high"
+    },
+    {
+      "item": "data-testid=scene-canvas on <Canvas>",
+      "reason": "Puppeteer uses this selector to detect scene readiness. The Canvas component must be updated to add this attribute.",
+      "severity": "medium"
+    },
+    {
+      "item": "puppeteer, serve, wait-on devDependencies",
+      "reason": "Three new devDependencies must be added to frontend/package.json. Review for version pinning and supply chain risk.",
+      "severity": "medium"
+    },
+    {
+      "item": "SwiftShader FPS threshold (Open Question #2 from LLD)",
+      "reason": "CI uses --use-gl=swiftshader for software rendering. FPS on SwiftShader may be lower than 60. Tech lead must confirm if 60 FPS threshold applies to SwiftShader or if a lower CI threshold is acceptable.",
+      "severity": "high"
+    },
+    {
+      "item": ".github/workflows/scalability-test.yml",
+      "reason": "PAT lacks workflow scope. Repo owner must manually push the CI workflow file. Content is provided in the PR body.",
+      "severity": "medium"
+    }
+  ],
+  "next_agent_context": {
+    "recommended_actions": [
+      "Review all test files for correctness against LLD Section 3 component specs",
+      "Verify BrickScenePopulator uses the correct sceneStore API (addBrick vs placeBrick)",
+      "Confirm FPSMeter measurement window (2000ms) is sufficient for statistical stability",
+      "Confirm HeapMonitor CDP method (Runtime.getHeapUsage) is available in Puppeteer v22",
+      "Review CI workflow YAML in PR body and push to .github/workflows/scalability-test.yml",
+      "Flag any issues with the --use-gl=swiftshader flag and 60 FPS threshold in CI",
+      "Approve or request changes on the PR"
+    ],
+    "files_to_read": [
+      "frontend/tests/performance/scalability.test.ts",
+      "frontend/tests/performance/helpers/BrickScenePopulator.ts",
+      "frontend/tests/performance/helpers/FPSMeter.ts",
+      "frontend/tests/performance/helpers/HeapMonitor.ts",
+      "frontend/tests/performance/helpers/ScalabilityThresholds.ts",
+      "frontend/tests/performance/fixtures/brickFixtures.ts",
+      "frontend/vitest.performance.config.ts",
+      "docs/features/NFR-SCALE-001/LOW_LEVEL_DESIGN.md"
+    ]
+  },
+  "alignment": {
+    "tcu_ids": ["TCU-NFR-SCALE-001"],
+    "forward_pass_score": 0.95,
+    "backward_pass_score": null,
+    "human_score": null,
+    "convergence_score": null
+  }
+}

--- a/frontend/tests/performance/fixtures/brickFixtures.ts
+++ b/frontend/tests/performance/fixtures/brickFixtures.ts
@@ -1,0 +1,68 @@
+/**
+ * brickFixtures.ts
+ * NFR-SCALE-001 — Pre-computed deterministic brick position data.
+ *
+ * Provides static fixture data for 100, 250, and 500 brick scenes.
+ * All positions are on a 25×20 grid with 2-unit spacing to avoid
+ * occupancy map collisions.
+ *
+ * Spectra-Agent: frontend-test
+ * Spectra-FRs: NFR-SCALE-001
+ * Spectra-Tests: T-PERF-SCALE-001-01, T-PERF-SCALE-001-02
+ */
+
+export interface BrickFixture {
+  id: string;
+  type: '2x4';
+  color: string;
+  position: { x: number; y: number; z: number };
+  rotation: { x: number; y: number; z: number };
+}
+
+const GRID_WIDTH = 25;
+const BRICK_SPACING = 2;
+const BRICK_COLOR = '#FF0000';
+
+/**
+ * Generate a deterministic array of brick fixtures for a given count.
+ * Bricks are placed on a 25-column grid at y=0 (ground plane).
+ */
+export function generateBrickFixtures(count: number): BrickFixture[] {
+  const fixtures: BrickFixture[] = [];
+  for (let i = 0; i < count; i++) {
+    fixtures.push({
+      id: `perf-brick-${i}`,
+      type: '2x4',
+      color: BRICK_COLOR,
+      position: {
+        x: (i % GRID_WIDTH) * BRICK_SPACING,
+        y: 0,
+        z: Math.floor(i / GRID_WIDTH) * BRICK_SPACING,
+      },
+      rotation: { x: 0, y: 0, z: 0 },
+    });
+  }
+  return fixtures;
+}
+
+/** Pre-computed fixture sets for each test tier */
+export const FIXTURES_100 = generateBrickFixtures(100);
+export const FIXTURES_250 = generateBrickFixtures(250);
+export const FIXTURES_500 = generateBrickFixtures(500);
+
+/**
+ * Verify no duplicate positions exist in a fixture set.
+ * Throws if any two bricks share the same (x, y, z) position.
+ */
+export function assertNoDuplicatePositions(fixtures: BrickFixture[]): void {
+  const seen = new Set<string>();
+  for (const brick of fixtures) {
+    const key = `${brick.position.x},${brick.position.y},${brick.position.z}`;
+    if (seen.has(key)) {
+      throw new Error(
+        `Duplicate position detected in fixtures: ${key} (brick id: ${brick.id})`
+      );
+    }
+    seen.add(key);
+  }
+}

--- a/frontend/tests/performance/helpers/BrickScenePopulator.ts
+++ b/frontend/tests/performance/helpers/BrickScenePopulator.ts
@@ -1,0 +1,102 @@
+/**
+ * BrickScenePopulator.ts
+ * NFR-SCALE-001 — Programmatic brick placement helper.
+ *
+ * Injects brick placement commands directly into sceneStore via
+ * page.evaluate() — no UI interaction required. Uses a deterministic
+ * 25×20 grid layout to avoid collision detection overhead and ensure
+ * reproducible scene geometry.
+ *
+ * Spectra-Agent: frontend-test
+ * Spectra-FRs: NFR-SCALE-001
+ * Spectra-Tests: T-PERF-SCALE-001-01, T-PERF-SCALE-001-02
+ */
+
+import type { Page } from 'puppeteer';
+import { GRID_WIDTH, BRICK_SPACING } from './ScalabilityThresholds.js';
+
+export class BrickScenePopulator {
+  /**
+   * Populate the scene with `count` bricks via sceneStore.addBrick().
+   *
+   * Bricks are placed on a deterministic grid:
+   *   x = (i % GRID_WIDTH) * BRICK_SPACING
+   *   z = Math.floor(i / GRID_WIDTH) * BRICK_SPACING
+   *   y = 0 (ground plane)
+   *
+   * @param page       Puppeteer Page instance with app loaded
+   * @param count      Number of bricks to place (100 | 250 | 500)
+   * @throws           If sceneStore is not exposed on window
+   */
+  static async populate(page: Page, count: number): Promise<void> {
+    await page.evaluate(
+      (brickCount: number, gridWidth: number, spacing: number) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const store = (window as any).__sceneStore;
+        if (!store) {
+          throw new Error(
+            'sceneStore not exposed on window — check main.tsx test mode guard. ' +
+              'Expected: if (import.meta.env.MODE !== "production") { (window as any).__sceneStore = useSceneStore; }'
+          );
+        }
+
+        const state = store.getState();
+        if (typeof state.addBrick !== 'function') {
+          throw new Error(
+            'sceneStore.addBrick is not a function — verify sceneStore API contract'
+          );
+        }
+
+        for (let i = 0; i < brickCount; i++) {
+          state.addBrick({
+            id: `perf-brick-${i}`,
+            type: '2x4',
+            color: '#FF0000',
+            position: {
+              x: (i % gridWidth) * spacing,
+              y: 0,
+              z: Math.floor(i / gridWidth) * spacing,
+            },
+            rotation: { x: 0, y: 0, z: 0 },
+          });
+        }
+      },
+      count,
+      GRID_WIDTH,
+      BRICK_SPACING
+    );
+  }
+
+  /**
+   * Clear all bricks from the scene via sceneStore.clearScene().
+   *
+   * @param page  Puppeteer Page instance with app loaded
+   * @throws      If sceneStore is not exposed on window
+   */
+  static async clear(page: Page): Promise<void> {
+    await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const store = (window as any).__sceneStore;
+      if (!store) {
+        throw new Error('sceneStore not exposed on window');
+      }
+      store.getState().clearScene();
+    });
+  }
+
+  /**
+   * Return the current brick count from sceneStore.
+   *
+   * @param page  Puppeteer Page instance with app loaded
+   * @returns     Number of bricks currently in the scene
+   */
+  static async getBrickCount(page: Page): Promise<number> {
+    return page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const store = (window as any).__sceneStore;
+      if (!store) return 0;
+      const state = store.getState();
+      return Array.isArray(state.bricks) ? state.bricks.length : 0;
+    });
+  }
+}

--- a/frontend/tests/performance/helpers/FPSMeter.ts
+++ b/frontend/tests/performance/helpers/FPSMeter.ts
@@ -1,0 +1,100 @@
+/**
+ * FPSMeter.ts
+ * NFR-SCALE-001 — requestAnimationFrame-based FPS measurement utility.
+ *
+ * Injects a rAF loop into the browser page context and collects frame
+ * timestamps over a configurable measurement window. Returns the average
+ * FPS over the window.
+ *
+ * Spectra-Agent: frontend-test
+ * Spectra-FRs: NFR-SCALE-001
+ * Spectra-Tests: T-PERF-SCALE-001-01, T-PERF-SCALE-001-02
+ */
+
+import type { Page } from 'puppeteer';
+
+export interface FPSMeasurement {
+  /** Average FPS over the measurement window */
+  averageFPS: number;
+  /** Total number of frames captured */
+  frameCount: number;
+  /** Actual elapsed time in milliseconds */
+  elapsedMs: number;
+  /** Minimum inter-frame interval in ms (worst frame) */
+  minFrameIntervalMs: number;
+  /** Maximum inter-frame interval in ms (best frame) */
+  maxFrameIntervalMs: number;
+}
+
+export class FPSMeter {
+  /**
+   * Measure FPS over `windowMs` milliseconds using requestAnimationFrame.
+   *
+   * Runs inside the browser context via page.evaluate(). The rAF loop
+   * collects DOMHighResTimeStamp values and computes average FPS from
+   * the total elapsed time and frame count.
+   *
+   * @param page      Puppeteer Page instance with app loaded
+   * @param windowMs  Measurement window in milliseconds (default: 2000)
+   * @returns         FPSMeasurement with averageFPS and diagnostics
+   */
+  static async measure(
+    page: Page,
+    windowMs: number = 2000
+  ): Promise<FPSMeasurement> {
+    return page.evaluate(
+      (durationMs: number): Promise<FPSMeasurement> => {
+        return new Promise((resolve) => {
+          const timestamps: number[] = [];
+          let rafId: number;
+          const startTime = performance.now();
+
+          function frame(ts: number): void {
+            timestamps.push(ts);
+            if (ts - startTime < durationMs) {
+              rafId = requestAnimationFrame(frame);
+            } else {
+              cancelAnimationFrame(rafId);
+
+              if (timestamps.length < 2) {
+                resolve({
+                  averageFPS: 0,
+                  frameCount: timestamps.length,
+                  elapsedMs: 0,
+                  minFrameIntervalMs: 0,
+                  maxFrameIntervalMs: 0,
+                });
+                return;
+              }
+
+              const elapsed =
+                timestamps[timestamps.length - 1] - timestamps[0];
+              const frameCount = timestamps.length - 1;
+              const averageFPS = (frameCount / elapsed) * 1000;
+
+              // Compute per-frame intervals for diagnostics
+              let minInterval = Infinity;
+              let maxInterval = 0;
+              for (let i = 1; i < timestamps.length; i++) {
+                const interval = timestamps[i] - timestamps[i - 1];
+                if (interval < minInterval) minInterval = interval;
+                if (interval > maxInterval) maxInterval = interval;
+              }
+
+              resolve({
+                averageFPS,
+                frameCount,
+                elapsedMs: elapsed,
+                minFrameIntervalMs: minInterval === Infinity ? 0 : minInterval,
+                maxFrameIntervalMs: maxInterval,
+              });
+            }
+          }
+
+          requestAnimationFrame(frame);
+        });
+      },
+      windowMs
+    );
+  }
+}

--- a/frontend/tests/performance/helpers/HeapMonitor.ts
+++ b/frontend/tests/performance/helpers/HeapMonitor.ts
@@ -1,0 +1,53 @@
+/**
+ * HeapMonitor.ts
+ * NFR-SCALE-001 — Chrome DevTools Protocol heap memory measurement utility.
+ *
+ * Uses CDP Runtime.getHeapUsage to measure current JS heap usage in MB.
+ * Forces a GC cycle before measurement for deterministic results.
+ *
+ * Spectra-Agent: frontend-test
+ * Spectra-FRs: NFR-SCALE-001
+ * Spectra-Tests: T-PERF-SCALE-001-02
+ */
+
+import type { CDPSession } from 'puppeteer';
+
+export interface HeapMeasurement {
+  /** Used heap size in megabytes (after GC) */
+  usedMB: number;
+  /** Total allocated heap size in megabytes */
+  totalMB: number;
+  /** Percentage of total heap that is used */
+  usagePercent: number;
+}
+
+export class HeapMonitor {
+  /**
+   * Measure current JS heap usage in MB via Chrome DevTools Protocol.
+   *
+   * Triggers a GC cycle first for deterministic measurement, then reads
+   * heap usage via Runtime.getHeapUsage.
+   *
+   * @param session  CDP session attached to the Puppeteer page
+   * @returns        HeapMeasurement with usedMB, totalMB, usagePercent
+   */
+  static async measure(session: CDPSession): Promise<HeapMeasurement> {
+    // Force GC to get a clean heap snapshot.
+    // HeapProfiler.collectGarbage is more reliable than Runtime.collectGarbage
+    // for triggering a full GC cycle.
+    try {
+      await session.send('HeapProfiler.collectGarbage');
+    } catch {
+      // HeapProfiler may not be enabled; fall back silently.
+      // Measurement will still proceed without GC.
+    }
+
+    const { usedSize, totalSize } = await session.send('Runtime.getHeapUsage');
+
+    const usedMB = usedSize / (1024 * 1024);
+    const totalMB = totalSize / (1024 * 1024);
+    const usagePercent = totalMB > 0 ? (usedMB / totalMB) * 100 : 0;
+
+    return { usedMB, totalMB, usagePercent };
+  }
+}

--- a/frontend/tests/performance/helpers/ScalabilityThresholds.ts
+++ b/frontend/tests/performance/helpers/ScalabilityThresholds.ts
@@ -1,0 +1,43 @@
+/**
+ * ScalabilityThresholds.ts
+ * NFR-SCALE-001 — Threshold constants for scalability performance tests.
+ *
+ * Spectra-Agent: frontend-test
+ * Spectra-FRs: NFR-SCALE-001
+ * Spectra-Tests: T-PERF-SCALE-001-01, T-PERF-SCALE-001-02
+ */
+
+/** Performance thresholds for NFR-SCALE-001 */
+export const THRESHOLDS = {
+  /** Minimum acceptable frame rate in frames per second */
+  MIN_FPS: 60,
+
+  /** Maximum acceptable JS heap usage in megabytes at 500 bricks */
+  MAX_HEAP_MB: 200,
+} as const;
+
+/**
+ * Milliseconds to wait after brick population before measuring FPS.
+ * Allows InstancedMesh matrix updates to flush and render loop to reach
+ * steady state.
+ */
+export const STABILIZATION_DELAY_MS = 500;
+
+/**
+ * Milliseconds over which to collect FPS samples.
+ * At 60 FPS this captures ≥120 frames for statistical stability.
+ */
+export const MEASUREMENT_WINDOW_MS = 2000;
+
+/** Brick counts to test per NFR-SCALE-001 acceptance criteria */
+export const BRICK_COUNTS = [100, 250, 500] as const;
+export type BrickCount = (typeof BRICK_COUNTS)[number];
+
+/**
+ * Grid width used for deterministic brick placement.
+ * 25 columns × 20 rows = 500 max bricks on a single layer.
+ */
+export const GRID_WIDTH = 25;
+
+/** Spacing between bricks in world units (2 studs per 2×4 brick width) */
+export const BRICK_SPACING = 2;

--- a/frontend/tests/performance/scalability.test.ts
+++ b/frontend/tests/performance/scalability.test.ts
@@ -1,0 +1,214 @@
+/**
+ * scalability.test.ts
+ * NFR-SCALE-001 — Scene Scalability Performance Test Suite
+ *
+ * Validates that the LegoBuilder 3D scene supports up to 500 bricks
+ * without performance degradation:
+ *   - Frame rate >= 60 FPS at 100, 250, and 500 bricks
+ *   - JS heap < 200 MB at 500 bricks
+ *
+ * Test Cases:
+ *   T-PERF-SCALE-001-01: 100 and 250 brick FPS >= 60
+ *   T-PERF-SCALE-001-02: 500 brick FPS >= 60 + heap < 200 MB
+ *
+ * Architecture:
+ *   - Puppeteer launches headless Chrome with CDP enabled
+ *   - BrickScenePopulator injects bricks via window.__sceneStore
+ *   - FPSMeter measures rAF-based FPS over a 2000ms window
+ *   - HeapMonitor reads heap via CDP Runtime.getHeapUsage
+ *
+ * Prerequisites:
+ *   - App must be built and served at http://localhost:5173
+ *   - window.__sceneStore must be exposed in non-production mode
+ *   - <Canvas data-testid="scene-canvas"> must be present
+ *
+ * Spectra-Agent: frontend-test
+ * Spectra-FRs: NFR-SCALE-001
+ * Spectra-Tests: T-PERF-SCALE-001-01, T-PERF-SCALE-001-02
+ */
+
+import {
+  describe,
+  test,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+  expect,
+} from 'vitest';
+import puppeteer, {
+  type Browser,
+  type Page,
+  type CDPSession,
+} from 'puppeteer';
+import { BrickScenePopulator } from './helpers/BrickScenePopulator.js';
+import { FPSMeter } from './helpers/FPSMeter.js';
+import { HeapMonitor } from './helpers/HeapMonitor.js';
+import {
+  THRESHOLDS,
+  STABILIZATION_DELAY_MS,
+  MEASUREMENT_WINDOW_MS,
+} from './helpers/ScalabilityThresholds.js';
+import {
+  assertNoDuplicatePositions,
+  generateBrickFixtures,
+} from './fixtures/brickFixtures.js';
+
+// ─── App URL ──────────────────────────────────────────────────────────────────
+const APP_URL = process.env['APP_URL'] ?? 'http://localhost:5173';
+const SCENE_CANVAS_SELECTOR = '[data-testid="scene-canvas"]';
+const PAGE_LOAD_TIMEOUT_MS = 30_000;
+
+// ─── Test Scenarios ───────────────────────────────────────────────────────────
+const SCENARIOS = [
+  { brickCount: 100, testId: 'T-PERF-SCALE-001-01', checkHeap: false },
+  { brickCount: 250, testId: 'T-PERF-SCALE-001-01', checkHeap: false },
+  { brickCount: 500, testId: 'T-PERF-SCALE-001-02', checkHeap: true },
+] as const;
+
+// ─── Suite ────────────────────────────────────────────────────────────────────
+describe('NFR-SCALE-001: Scene Scalability — 100/250/500 Bricks', () => {
+  let browser: Browser;
+  let page: Page;
+  let cdpSession: CDPSession;
+
+  // ── Fixture integrity checks (no browser needed) ──────────────────────────
+  test('fixture integrity: no duplicate positions in 500-brick set', () => {
+    const fixtures = generateBrickFixtures(500);
+    expect(() => assertNoDuplicatePositions(fixtures)).not.toThrow();
+    expect(fixtures).toHaveLength(500);
+  });
+
+  test('fixture integrity: 100-brick set is a prefix of 500-brick set', () => {
+    const fixtures100 = generateBrickFixtures(100);
+    const fixtures500 = generateBrickFixtures(500);
+    for (let i = 0; i < 100; i++) {
+      expect(fixtures100[i].id).toBe(fixtures500[i].id);
+      expect(fixtures100[i].position).toEqual(fixtures500[i].position);
+    }
+  });
+
+  // ── Browser lifecycle ─────────────────────────────────────────────────────
+  beforeAll(async () => {
+    browser = await puppeteer.launch({
+      headless: true,
+      args: [
+        '--no-sandbox',
+        '--disable-setuid-sandbox',
+        '--enable-gpu',
+        '--use-gl=swiftshader', // Software rendering fallback for CI
+        '--disable-dev-shm-usage',
+        '--disable-extensions',
+      ],
+    });
+  }, 30_000);
+
+  afterAll(async () => {
+    try {
+      await browser.close();
+    } catch {
+      // Browser may already be closed
+    }
+  });
+
+  beforeEach(async () => {
+    page = await browser.newPage();
+    cdpSession = await page.target().createCDPSession();
+
+    // Navigate to app and wait for scene canvas
+    await page.goto(APP_URL, {
+      waitUntil: 'networkidle0',
+      timeout: PAGE_LOAD_TIMEOUT_MS,
+    });
+
+    await page
+      .waitForSelector(SCENE_CANVAS_SELECTOR, {
+        timeout: PAGE_LOAD_TIMEOUT_MS,
+      })
+      .catch(() => {
+        throw new Error(
+          `Scene canvas not found at selector "${SCENE_CANVAS_SELECTOR}" — ` +
+            'app may have crashed or <Canvas data-testid="scene-canvas"> is missing'
+        );
+      });
+  }, 35_000);
+
+  afterEach(async () => {
+    try {
+      await cdpSession.detach();
+    } catch {
+      // Already detached
+    }
+    try {
+      await page.close();
+    } catch {
+      // Already closed
+    }
+  });
+
+  // ── Performance scenarios ─────────────────────────────────────────────────
+  test.each(SCENARIOS)(
+    '$testId: $brickCount bricks — FPS >= 60 (heap check: $checkHeap)',
+    async ({ brickCount, checkHeap }) => {
+      // ── Phase 1: Populate scene ──────────────────────────────────────────
+      await BrickScenePopulator.populate(page, brickCount);
+
+      // Verify brick count was applied
+      const actualCount = await BrickScenePopulator.getBrickCount(page);
+      expect(actualCount).toBe(brickCount);
+
+      // ── Phase 2: Stabilize render loop ───────────────────────────────────
+      await new Promise<void>((resolve) =>
+        setTimeout(resolve, STABILIZATION_DELAY_MS)
+      );
+
+      // ── Phase 3: Measure FPS ─────────────────────────────────────────────
+      const fpsMeasurement = await FPSMeter.measure(page, MEASUREMENT_WINDOW_MS);
+
+      console.log(
+        `[NFR-SCALE-001] ${brickCount} bricks: ` +
+          `avgFPS=${fpsMeasurement.averageFPS.toFixed(1)}, ` +
+          `frames=${fpsMeasurement.frameCount}, ` +
+          `elapsed=${fpsMeasurement.elapsedMs.toFixed(0)}ms, ` +
+          `minInterval=${fpsMeasurement.minFrameIntervalMs.toFixed(1)}ms, ` +
+          `maxInterval=${fpsMeasurement.maxFrameIntervalMs.toFixed(1)}ms`
+      );
+
+      expect(
+        fpsMeasurement.averageFPS,
+        `FPS degradation at ${brickCount} bricks: ` +
+          `measured ${fpsMeasurement.averageFPS.toFixed(1)} FPS, ` +
+          `threshold is ${THRESHOLDS.MIN_FPS} FPS. ` +
+          `Frames captured: ${fpsMeasurement.frameCount} over ` +
+          `${fpsMeasurement.elapsedMs.toFixed(0)}ms. ` +
+          `Check InstancedMesh batching (FR-SCENE-002) for regressions.`
+      ).toBeGreaterThanOrEqual(THRESHOLDS.MIN_FPS);
+
+      // ── Phase 4: Measure heap (500-brick tier only) ──────────────────────
+      if (checkHeap) {
+        const heapMeasurement = await HeapMonitor.measure(cdpSession);
+
+        console.log(
+          `[NFR-SCALE-001] ${brickCount} bricks heap: ` +
+            `used=${heapMeasurement.usedMB.toFixed(1)}MB, ` +
+            `total=${heapMeasurement.totalMB.toFixed(1)}MB, ` +
+            `usage=${heapMeasurement.usagePercent.toFixed(1)}%`
+        );
+
+        expect(
+          heapMeasurement.usedMB,
+          `Memory exceeded at ${brickCount} bricks: ` +
+            `measured ${heapMeasurement.usedMB.toFixed(1)}MB, ` +
+            `threshold is ${THRESHOLDS.MAX_HEAP_MB}MB. ` +
+            `Check for memory leaks in sceneStore or InstancedMesh buffers.`
+        ).toBeLessThan(THRESHOLDS.MAX_HEAP_MB);
+      }
+
+      // ── Phase 5: Clean up scene for next test ────────────────────────────
+      await BrickScenePopulator.clear(page);
+    },
+    // Per-test timeout: browser startup (30s) + population + stabilization +
+    // measurement window (2s) + heap measurement + cleanup
+    90_000
+  );
+});

--- a/frontend/vitest.performance.config.ts
+++ b/frontend/vitest.performance.config.ts
@@ -1,0 +1,50 @@
+/**
+ * vitest.performance.config.ts
+ * NFR-SCALE-001 — Vitest configuration for performance tests.
+ *
+ * Isolated from the unit test suite to:
+ *   - Avoid inflating coverage numbers with performance scaffolding
+ *   - Allow longer timeouts for browser-based tests
+ *   - Run tests sequentially (Puppeteer sessions cannot be parallelized)
+ *
+ * Usage:
+ *   npx vitest run --config vitest.performance.config.ts
+ *
+ * Spectra-Agent: frontend-test
+ * Spectra-FRs: NFR-SCALE-001
+ */
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'performance',
+    include: ['tests/performance/**/*.test.ts'],
+    exclude: ['tests/unit/**', 'tests/component/**', 'tests/e2e/**'],
+
+    // Puppeteer runs in Node context — not jsdom
+    environment: 'node',
+
+    // 2 minutes per test: browser startup + 3 brick tiers + measurement windows
+    testTimeout: 120_000,
+
+    // 30 seconds for browser launch in beforeAll
+    hookTimeout: 30_000,
+
+    // Verbose output for CI diagnostics + JSON for artifact upload
+    reporters: ['verbose', 'json'],
+    outputFile: 'tests/performance/scalability-report.json',
+
+    // No coverage — performance tests are not coverage targets
+    coverage: { enabled: false },
+
+    // Sequential execution — Puppeteer browser sessions cannot be safely
+    // parallelized across workers
+    pool: 'forks',
+    poolOptions: {
+      forks: {
+        singleFork: true,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Gate 6b — Frontend Test Review: NFR-SCALE-001

### Summary
Implements the complete performance test suite for **NFR-SCALE-001** (Scene Scalability — 500 Bricks). Validates that the LegoBuilder 3D scene supports up to 500 bricks without performance degradation (≥60 FPS, heap <200 MB) using Puppeteer + Chrome DevTools Protocol.

**FR-ID:** NFR-SCALE-001 | **Issue:** #30 | **Test Cases:** T-PERF-SCALE-001-01, T-PERF-SCALE-001-02

---

### Artifacts

| File | Description |
|------|-------------|
| `frontend/tests/performance/scalability.test.ts` | Main Vitest + Puppeteer test suite — 3 scenarios (100/250/500 bricks) |
| `frontend/tests/performance/helpers/ScalabilityThresholds.ts` | Threshold constants: MIN_FPS=60, MAX_HEAP_MB=200 |
| `frontend/tests/performance/helpers/BrickScenePopulator.ts` | Programmatic brick placement via `window.__sceneStore` |
| `frontend/tests/performance/helpers/FPSMeter.ts` | rAF-based FPS measurement over 2000ms window |
| `frontend/tests/performance/helpers/HeapMonitor.ts` | CDP `Runtime.getHeapUsage` heap measurement |
| `frontend/tests/performance/fixtures/brickFixtures.ts` | Deterministic 25×20 grid brick position fixtures |
| `frontend/vitest.performance.config.ts` | Isolated Vitest config (Node env, 120s timeout, sequential) |

---

### Key Decisions

- **Puppeteer + CDP** — Real in-browser FPS and heap measurement (jsdom cannot measure real FPS)
- **`window.__sceneStore` injection** — Deterministic, UI-free brick placement via `page.evaluate()`
- **`--use-gl=swiftshader`** — Software rendering fallback for CI environments without GPU
- **2000ms FPS window** — Statistical stability (≥120 frames at 60 FPS)
- **500ms stabilization delay** — Allows InstancedMesh matrix updates to flush before measuring
- **Sequential execution** (`singleFork: true`) — Puppeteer sessions cannot be safely parallelized

---

### Spectra Workflow Summary

| Agent | Action | Model Tier |
|-------|--------|------------|
| design-agent | Authored LOW_LEVEL_DESIGN.md for NFR-SCALE-001 | frontier |
| frontend-test | Authored performance test suite (this PR) | frontier |

---

### App Integration Required (Not in This PR)

The following changes must be made to the **production app** before these tests can run. They are **not** included in this PR (test-only branch):

1. **`frontend/src/main.tsx`** — Expose `sceneStore` on `window` in non-production mode:
   ```typescript
   if (import.meta.env.MODE !== 'production') {
     import('./stores/sceneStore').then(({ useSceneStore }) => {
       (window as any).__sceneStore = useSceneStore;
     });
   }
   ```

2. **`<Canvas>` component** — Add `data-testid="scene-canvas"` attribute:
   ```tsx
   <Canvas data-testid="scene-canvas" ...>
   ```

3. **`frontend/package.json`** — Add devDependencies:
   ```json
   "puppeteer": "^22.0.0",
   "serve": "^14.0.0",
   "wait-on": "^7.0.0"
   ```

---

### CI Workflow (Requires Manual Push)

> ⚠️ The PAT used by the Spectra agent lacks `workflow` scope. The repo owner must manually push `.github/workflows/scalability-test.yml` with the following content:

```yaml
name: Scalability Test (NFR-SCALE-001)

on:
  pull_request:
    branches: [main]
    paths:
      - 'frontend/**'
      - '.github/workflows/scalability-test.yml'
  push:
    branches: [main]
    paths:
      - 'frontend/**'

jobs:
  scalability-test:
    name: Scalability — 100/250/500 Bricks
    runs-on: ubuntu-latest
    timeout-minutes: 20

    steps:
      - uses: actions/checkout@v4

      - name: Setup Node.js 20
        uses: actions/setup-node@v4
        with:
          node-version: '20'
          cache: 'npm'
          cache-dependency-path: frontend/package-lock.json

      - name: Install dependencies
        working-directory: frontend
        run: npm ci

      - name: Install Puppeteer Chrome
        working-directory: frontend
        run: npx puppeteer browsers install chrome

      - name: Build application
        working-directory: frontend
        run: npm run build
        env:
          NODE_ENV: test

      - name: Serve built application
        working-directory: frontend
        run: npx serve dist -p 5173 &

      - name: Wait for server
        run: npx wait-on http://localhost:5173 --timeout 30000

      - name: Run scalability tests
        working-directory: frontend
        run: npx vitest run --config vitest.performance.config.ts --reporter=verbose
        env:
          PUPPETEER_HEADLESS: 'true'
          CI: 'true'
          APP_URL: 'http://localhost:5173'

      - name: Upload scalability report
        if: always()
        uses: actions/upload-artifact@v4
        with:
          name: scalability-report-${{ github.sha }}
          path: frontend/tests/performance/scalability-report.json
          retention-days: 30
          if-no-files-found: warn
```

---

### Review Checklist

- [ ] Artifact follows the Spectra scaffold template
- [ ] All placeholders filled with project-specific content
- [ ] No TODO / TBD / placeholder text remains
- [ ] Consistent with LLD (docs/features/NFR-SCALE-001/LOW_LEVEL_DESIGN.md)
- [ ] `BrickScenePopulator` uses correct `sceneStore` API (`addBrick` vs `placeBrick`)
- [ ] `FPSMeter` measurement window (2000ms) is sufficient for statistical stability
- [ ] `HeapMonitor` CDP method (`Runtime.getHeapUsage`) is available in Puppeteer v22
- [ ] SwiftShader FPS threshold decision made (LLD Open Question #2)
- [ ] App integration changes (main.tsx, Canvas, package.json) are planned
- [ ] CI workflow YAML reviewed and pushed to `.github/workflows/`
- [ ] Ready for human approval

---

*Created by Spectra Framework — frontend-test agent | Handoff: 026_frontend-test_nfr_scale_001_complete*